### PR TITLE
fix: more cleaner model processor with /proc/cpuinfo

### DIFF
--- a/benchy
+++ b/benchy
@@ -597,7 +597,7 @@ sysinfo() {
       if [ -n "$is_bsd" ]; then
 					cpu_model=$(sysctl -n hw.model)
       else
-					cpu_model=$(awk -F: '/model name/{ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}}' /proc/cpuinfo | sed 's/\(.\{41\}\).*/\1/')
+					cpu_model=$(awk -F: '/model name/{ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}}' /proc/cpuinfo | sed 's/\(.\{41\}\).*/\1/' | cut -d @ -f1 | tr -s ' ')
       fi
   fi
   # CPU Frequency


### PR DESCRIPTION
On some process `/proc/cpuinfo` was return with weird spacing and
wasting hardware info space. For example was on processor
Core 2 Duo P8600
```
$ cat /proc/cpuinfo
processor       : 0
vendor_id       : GenuineIntel
cpu family      : 6
model           : 23
model name      : Intel(R) Core(TM)2 Duo CPU     P8600  @ 2.40GHz
...
```

The result was after this commit was something like this
```
Model       : Intel(R) Core(TM)2 Duo CPU P8600
```

This commit include with split remove string after @ cause we only
need get process name

Tested on
- Ubuntu 20.04
- Alpine linux 3.18_alpha20230208
- CentOS Linux 7.9.2009 (Core)
